### PR TITLE
Add tile catalog website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 Il file è il codice python con ultima modifica con le news degli articoli
+
+## Tile Catalog Website
+
+Run `python tile_catalog.py` and open http://localhost:5000 to view a catalog of 400 tiles.

--- a/templates/catalog.html
+++ b/templates/catalog.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Tile Catalog</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        table { border-collapse: collapse; width: 100%; }
+        th, td { border: 1px solid #ddd; padding: 8px; text-align: left; }
+        th { background-color: #f2f2f2; }
+    </style>
+</head>
+<body>
+    <h1>Catalogo Piastrelle</h1>
+    <table>
+        <tr>
+            <th>ID</th>
+            <th>Nome</th>
+            <th>Colore</th>
+            <th>Dimensione</th>
+        </tr>
+        {% for tile in tiles %}
+        <tr>
+            <td>{{ tile.id }}</td>
+            <td>{{ tile.name }}</td>
+            <td>{{ tile.color }}</td>
+            <td>{{ tile.size }}</td>
+        </tr>
+        {% endfor %}
+    </table>
+</body>
+</html>

--- a/tile_catalog.py
+++ b/tile_catalog.py
@@ -1,0 +1,25 @@
+import random
+from flask import Flask, render_template
+
+app = Flask(__name__)
+
+# Generate 400 tile items with sample data
+TILES = []
+COLORS = ["Red", "Blue", "Green", "Yellow", "White", "Black", "Gray", "Beige"]
+SIZES = ["10x10", "15x15", "20x20", "30x30", "60x60"]
+
+for i in range(1, 401):
+    tile = {
+        "id": i,
+        "name": f"Tile {i}",
+        "color": random.choice(COLORS),
+        "size": random.choice(SIZES)
+    }
+    TILES.append(tile)
+
+@app.route('/')
+def catalog():
+    return render_template('catalog.html', tiles=TILES)
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- add flask-based tile catalog website with 400 sample items
- render catalog with a simple HTML table
- update README with instructions on running the site

## Testing
- `python -m py_compile tile_catalog.py`

------
https://chatgpt.com/codex/tasks/task_e_684479e0798083299cd69dfdd767dbaf